### PR TITLE
Note editing form

### DIFF
--- a/src/containers/App/index.js
+++ b/src/containers/App/index.js
@@ -22,7 +22,7 @@ export class App extends Component {
           const { id } = match.params;
           const foundNote = this.props.notes.find(note => note.id === id);
           if (foundNote) {
-            return < Form foundNote={foundNote} />
+            return < Form foundNote={foundNote}/>
           }
         }} />
       </div>

--- a/src/containers/App/index.js
+++ b/src/containers/App/index.js
@@ -21,7 +21,9 @@ export class App extends Component {
         <Route path='/notes/:id' render={({ match }) => {
           const { id } = match.params;
           const foundNote = this.props.notes.find(note => note.id === id);
-          return < Form foundNote={foundNote} />
+          if (foundNote) {
+            return < Form foundNote={foundNote} />
+          }
         }} />
       </div>
     )

--- a/src/containers/Form/index.js
+++ b/src/containers/Form/index.js
@@ -24,6 +24,14 @@ export class Form extends Component {
     }
   }
 
+  shouldComponentUpdate(nextProps, prevState) {
+    if(nextProps.foundNote.id !== prevState.id) {
+      const { id, title, listItems } = this.props.foundNote;
+      this.setState({ id, title, listItems, editing: true })
+      return false;
+    } else return true;
+  }
+
   handleChange = ({ target }) => {
     this.setState({ [target.name]: target.value })
   }
@@ -71,6 +79,7 @@ export class Form extends Component {
             placeholder='Title' 
             type='text'
             name='title'
+            value={ this.state.title }
             onChange={ this.handleChange } /> 
         </div>
         <div>

--- a/src/containers/Form/index.js
+++ b/src/containers/Form/index.js
@@ -47,8 +47,13 @@ export class Form extends Component {
     })
   }
 
-  editNote = () => {
-
+  editNote = async () => {
+    const { id, listItems, title} = this.state;
+    try {
+      await putNote({ id, listItems, title });
+    } catch(error) {
+      console.log(error)
+    }
   }
 
   addNote = () => {
@@ -104,7 +109,7 @@ export class Form extends Component {
             onBlur={ this.handleSubmit }
             autoFocus />
         </form>
-        <button onClick={ this.addNote }>Save</button>
+        <button onClick={ () => this.state.editing ? this.editNote() : this.addNote() }>Save</button>
       </div>
     )
   }

--- a/src/containers/Form/index.js
+++ b/src/containers/Form/index.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import ListItem from '../ListItem';
 import { addNewNote } from '../../thunks/addNewNote';
 import { connect } from 'react-redux';
+import { updateNote } from '../../actions/index';
 import { PropTypes } from 'prop-types';
 import  uuidv4 from 'uuid/v4';
 import { putNote } from '../../utils/apiFetches/putNote';
@@ -51,6 +52,7 @@ export class Form extends Component {
     const { id, listItems, title} = this.state;
     try {
       await putNote({ id, listItems, title });
+      this.props.updateExistingNote({ id, listItems, title });
     } catch(error) {
       console.log(error)
     }
@@ -117,7 +119,8 @@ export class Form extends Component {
 }
 
 export const mapDispatchToProps = dispatch => ({
-  addNewNote: (note) => dispatch(addNewNote(note))
+  addNewNote: (note) => dispatch(addNewNote(note)),
+  updateExistingNote: (note) => dispatch(updateNote(note))
 })
 
 export default connect(null, mapDispatchToProps)(Form);

--- a/src/containers/Form/index.js
+++ b/src/containers/Form/index.js
@@ -54,6 +54,7 @@ export class Form extends Component {
     } catch(error) {
       console.log(error)
     }
+    this.setState({ editing: false })
   }
 
   addNote = () => {

--- a/src/containers/Form/index.js
+++ b/src/containers/Form/index.js
@@ -4,6 +4,7 @@ import { addNewNote } from '../../thunks/addNewNote';
 import { connect } from 'react-redux';
 import { PropTypes } from 'prop-types';
 import  uuidv4 from 'uuid/v4';
+import { putNote } from '../../utils/apiFetches/putNote';
 
 export class Form extends Component {
   constructor() {
@@ -24,12 +25,12 @@ export class Form extends Component {
     }
   }
 
-  shouldComponentUpdate(nextProps, prevState) {
-    if(nextProps.foundNote.id !== prevState.id) {
-      const { id, title, listItems } = this.props.foundNote;
-      this.setState({ id, title, listItems, editing: true })
-      return false;
-    } else return true;
+  static getDerivedStateFromProps(props, state) {
+    if (!props.foundNote) return null;
+    if (props.foundNote.id !== state.id) {
+      const { id, title, listItems } = props.foundNote;
+      return { id, title, listItems, editing: true }
+    } else return null;
   }
 
   handleChange = ({ target }) => {
@@ -44,6 +45,10 @@ export class Form extends Component {
       listItems: [...this.state.listItems, newItem],
       listItemText: ''
     })
+  }
+
+  editNote = () => {
+
   }
 
   addNote = () => {

--- a/src/containers/Form/index.js
+++ b/src/containers/Form/index.js
@@ -100,6 +100,7 @@ export class Form extends Component {
             return (
             <ListItem 
               item={ item }
+              editing={ this.state.editing }
               updateListItems={ this.updateListItems } />
           )})}
         </div>

--- a/src/containers/ListItem/_ListItem.scss
+++ b/src/containers/ListItem/_ListItem.scss
@@ -5,3 +5,7 @@
 .item-container {
   border: 1px dashed black;
 }
+
+.completed-item {
+  text-decoration: line-through;
+}

--- a/src/containers/ListItem/index.js
+++ b/src/containers/ListItem/index.js
@@ -48,8 +48,8 @@ export class ListItem extends Component {
   }
   
   render() {
-    const { id } = this.props.item;
-    
+    const { id, completed } = this.props.item;
+    console.log(this.props.editing)
     const form = (
       <form onSubmit={ this.handleSubmit }>
         <input
@@ -67,8 +67,17 @@ export class ListItem extends Component {
             ? form
             : (
               <div className="item-container">
-                <button onClick={ this.checkItem }>done</button>
-                <p onClick={ this.editItem }>{this.props.item.body || this.state.body }</p>
+                <button 
+                  onClick={ this.checkItem }>
+                  done
+                </button>
+                <p 
+                  onClick={ this.props.editing && this.editItem }
+                  className={ completed 
+                    ? 'completed-item list-item' 
+                    : 'list-item'}>    
+                    {this.props.item.body || this.state.body }
+                </p>
                 <button onClick={ this.deleteItem }>x</button>
               </div>
               )

--- a/src/containers/ListItem/index.js
+++ b/src/containers/ListItem/index.js
@@ -66,9 +66,9 @@ export class ListItem extends Component {
         { this.state.editable 
             ? form
             : (
-              <div onClick={ this.editItem } className="item-container">
+              <div className="item-container">
                 <button onClick={ this.checkItem }>done</button>
-                <p onClick={ this.checkItem }>{this.props.item.body || this.state.body }</p>
+                <p onClick={ this.editItem }>{this.props.item.body || this.state.body }</p>
                 <button onClick={ this.deleteItem }>x</button>
               </div>
               )

--- a/src/containers/ListItem/index.js
+++ b/src/containers/ListItem/index.js
@@ -66,9 +66,9 @@ export class ListItem extends Component {
         { this.state.editable 
             ? form
             : (
-              <div className="item-container">
+              <div onClick={ this.editItem } className="item-container">
                 <button onClick={ this.checkItem }>done</button>
-                <p onClick={ this.editItem }>{this.props.item.body || this.state.body}</p>
+                <p onClick={ this.checkItem }>{this.props.item.body || this.state.body }</p>
                 <button onClick={ this.deleteItem }>x</button>
               </div>
               )

--- a/src/containers/NoteCard/index.js
+++ b/src/containers/NoteCard/index.js
@@ -47,7 +47,7 @@ export class NoteCard extends Component {
 
   render() {
     const listItems = this.props.note.listItems.map(item => (
-      <p>
+      <p className={ item.completed ? 'completed-item list-item' : 'list-item'}>
         { item.body }
       </p>
     ))

--- a/src/containers/NoteCard/index.js
+++ b/src/containers/NoteCard/index.js
@@ -9,6 +9,7 @@ export class NoteCard extends Component {
   constructor() {
     super();
     this.state = {
+
     }
   }
 
@@ -17,7 +18,6 @@ export class NoteCard extends Component {
   }
 
   updateListItems = (newItem, remove) => {
-    // make updated note with list item
     let updateListItems;
     if (remove) {
       updateListItems = [...this.state.listItems].filter(listItem => listItem.id !== newItem.id);
@@ -47,10 +47,9 @@ export class NoteCard extends Component {
 
   render() {
     const listItems = this.props.note.listItems.map(item => (
-      < ListItem updateListItems={ this.updateListItems } item={ item } />
-      // <p className={ item.completed ? 'completed-item list-item' : 'list-item'}>
-      //   { item.body }
-      // </p>
+      < ListItem 
+        updateListItems={ this.updateListItems } 
+        item={ item } />
     ))
 
     return (

--- a/src/containers/NoteCard/index.js
+++ b/src/containers/NoteCard/index.js
@@ -47,9 +47,10 @@ export class NoteCard extends Component {
 
   render() {
     const listItems = this.props.note.listItems.map(item => (
-      <p className={ item.completed ? 'completed-item list-item' : 'list-item'}>
-        { item.body }
-      </p>
+      < ListItem updateListItems={ this.updateListItems } item={ item } />
+      // <p className={ item.completed ? 'completed-item list-item' : 'list-item'}>
+      //   { item.body }
+      // </p>
     ))
 
     return (
@@ -69,7 +70,6 @@ export class NoteCard extends Component {
 const mapDispatchToProps = dispatch => ({
   updateNote: note => dispatch(updateNote(note)),
   removeNote: id=> dispatch(deleteNote(id))
-
 })
 
 export default connect(null, mapDispatchToProps)(NoteCard);

--- a/src/containers/NoteCard/index.js
+++ b/src/containers/NoteCard/index.js
@@ -5,6 +5,8 @@ import { updateNote } from '../../actions/index';
 import { connect } from 'react-redux';
 import { deleteNote } from '../../actions';
 import { deleteNoteFetch } from '../../utils/apiFetches/deleteNote';
+import { putNote } from '../../utils/apiFetches/putNote';
+
 export class NoteCard extends Component {
   constructor() {
     super();
@@ -27,11 +29,19 @@ export class NoteCard extends Component {
           return newItem;
         } else return listItem;
       })
-    } 
+    }
+    this.updateStateAndDatabase(updateListItems);
+  }
 
-    this.setState({ listItems: updateListItems }, () => 
+  updateStateAndDatabase(updatedItems) {
+    this.setState({ listItems: updatedItems }, async () => {
       this.props.updateExistingNote({...this.state})
-    );
+      try {
+        await putNote({ ...this.state })
+      } catch(error) {
+        console.log(error);
+      }
+    });
   }
 
   deleteNote = async() => {

--- a/src/containers/NoteCard/index.js
+++ b/src/containers/NoteCard/index.js
@@ -3,8 +3,8 @@ import ListItem from '../../containers/ListItem';
 import { Link } from 'react-router-dom'
 import { updateNote } from '../../actions/index';
 import { connect } from 'react-redux';
-import {deleteNote} from '../../actions';
-import {deleteNoteFetch} from '../../utils/apiFetches/deleteNote';
+import { deleteNote } from '../../actions';
+import { deleteNoteFetch } from '../../utils/apiFetches/deleteNote';
 export class NoteCard extends Component {
   constructor() {
     super();
@@ -30,7 +30,7 @@ export class NoteCard extends Component {
     } 
 
     this.setState({ listItems: updateListItems }, () => 
-      this.props.updateNote({...this.state})
+      this.props.updateExistingNote({...this.state})
     );
   }
 
@@ -67,7 +67,7 @@ export class NoteCard extends Component {
 }
 
 const mapDispatchToProps = dispatch => ({
-  updateNote: note => dispatch(updateNote(note)),
+  updateExistingNote: note => dispatch(updateNote(note)),
   removeNote: id=> dispatch(deleteNote(id))
 })
 

--- a/src/reducers/notesReducer.js
+++ b/src/reducers/notesReducer.js
@@ -9,7 +9,6 @@ export const notesReducer = (state = [], action) => {
         note.id !== action.id
       )
     case 'UPDATE_NOTE':
-      console.log(action.note);
       const updated = [...state].map(note => {
         if (note.id === action.note.id) {
           return action.note;

--- a/src/utils/apiFetches/putNote.js
+++ b/src/utils/apiFetches/putNote.js
@@ -1,0 +1,16 @@
+export const putNote = async (id, note) => {
+  const url = `http://localhost:3000/api/v1/notes/${id}`;
+  const response = await fetch(url, {
+    method: 'PUT',
+    body: JSON.stringify(note),
+    headers: {
+      "Content-type": "application/json"
+    }
+  })
+
+  if (!response.ok) {
+    throw Error('Failed to update note');
+  }
+
+  return response;
+}

--- a/src/utils/apiFetches/putNote.js
+++ b/src/utils/apiFetches/putNote.js
@@ -1,5 +1,5 @@
-export const putNote = async (id, note) => {
-  const url = `http://localhost:3000/api/v1/notes/${id}`;
+export const putNote = async (note) => {
+  const url = `http://localhost:3000/api/v1/notes/${note.id}`;
   const response = await fetch(url, {
     method: 'PUT',
     body: JSON.stringify(note),


### PR DESCRIPTION
- The form now renders based on the current note url path or on click of the note
- This persists on refresh so its good
ALSO:
- The put fetch request is submitted when they save the edited form, it just NOT updates our current redux state, that would need to get done. When you refresh the page, the edits are now persisting

closes #5 

ADDITION:
- I converted the rendered notecard items back to the listitem component because we forgot that the listitem component had all the event listeners we had to update notecard live. I think it's better to be able to update the notecard on the go instead of opening it in the form.
- The list items is NOT immediately editable, there is a conditional only passed within the notecard url to make sure that its only editable within the form
- Imported the put request to the notecard so that it can be updated whenever the user deletes/updates a notecard
- There is a conditional style for completed  list items, it works now and it persists on refresh
